### PR TITLE
Merge changes for automatic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ will make the texts more accessible.
 ## Updating
 
 Cuneiform transcriptions are normally maintained in the
-[ATF]() format. To add new texts or update the collection
-run the export through the `atf2cts` tool from the
-[atf2tei](https://github.com/cdli-gh/atf2tei) package.
+[ATF](http://oracc.museum.upenn.edu/doc/help/editinginatf/primer/) format.
+To add new texts or update the collection run the export through
+the `atf2cts` tool from the [atf2tei](https://github.com/cdli-gh/atf2tei)
+package.
 
 For example, fetch the latest data export published by
 the cdli:

--- a/README.md
+++ b/README.md
@@ -15,29 +15,49 @@ will make the texts more accessible.
   [data repository](https://github.com/cdli-gh/data).
 - Layout following the [CapiTainS Guidelines](http://capitains.org/pages/guidelines).
 
-## Updating
+## Adding files
 
 Cuneiform transcriptions are normally maintained in the
 [ATF](http://oracc.museum.upenn.edu/doc/help/editinginatf/primer/) format.
-To add new texts or update the collection run the export through
+To add new texts or update the collection run the transcriptions through
 the `atf2cts` tool from the [atf2tei](https://github.com/cdli-gh/atf2tei)
 package.
 
-For example, fetch the latest data export published by
-the cdli:
+For example, to convert a atf file containing one or more tablet
+transcriptions and add it to the repository:
 
 ```
-curl -O https://raw.githubusercontent.com/cdli-gh/data/master/cdliatf_unblocked.atf
-```
-
-Now convert the data and replace the copy in this repository checkout:
-
-```
+pip install pipenv # if necessar.
 git clone https://github.com/cdli-gh/atf2tei
 cd atf2tei
 pipenv install
-pipenv run python atf2cts.py ../cdliatf_unblocked.atf
-mv data ../
+pipenv run python atf2cts.py /path/to/your/transcription.atf
+mv data/* ../data/
 ```
 
-A simple `git status` should then show the changed files.
+A simple `git status` should then show the added (or changed) files.
+
+## Updating
+
+There is also a script in the update directory which reads the entire
+CDLI bulk data export and converts a subset of the records, based
+on a list of CDLI id numbers or particular catalogue field entries.
+
+```
+git clone --depth https://github.com/cdli-gh/data cdli-data
+pipenv install pyoracc
+PYTHONPATH=$PWD/atf2tei update/cdli2cts.py -d cdli-data -o .
+```
+
+The data repository is quite large. Passing the `--depth` option
+to git downloads only the most recent changes, reducing the size
+to several hundred MB.
+
+Until `atf2cts` is properly packaged, it also needs to be checked
+out with git and the location passed through the `PYTHONPATH`
+environment variable. See the section above about added files
+for how to do this.
+
+A docker container configuration is included which can be used
+to set up automatic updates. See [update](update/README.md) for
+details.

--- a/update/Dockerfile
+++ b/update/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.7-alpine
+
+# Install pipenv for dependency management.
+RUN pip install pipenv
+
+# Work in the default python container source location.
+WORKDIR /usr/src/app
+
+# Install git for repo access.
+RUN apk add git
+
+# Install ssh for deploying updates.
+RUN apk add openssh-client
+RUN ssh -o 'StrictHostKeyChecking no' -N git@github.com || true
+
+# Setup runtime.
+RUN git clone https://github.com/cdli-gh/atf2tei
+RUN pipenv install pyoracc
+
+# Copy source.
+ADD cdli2cts.py .
+ADD cdli.py .
+ADD run.sh .
+
+CMD ./run.sh --setup

--- a/update/README.md
+++ b/update/README.md
@@ -1,0 +1,59 @@
+# Canonical Cuneiform Text Scripts
+
+This directory contains scripts for maintaining the data in
+the rest of the repository, and is intended for developers.
+
+Specifically `Dockerfile` describes a container which invokes
+the `run.sh` script to periodically pull changes from the
+bulk data export repository, filter them through `cdli2cts`,
+and push the changes.
+
+To set this up, change to this directory and execute:
+
+```
+docker build -t cdli-cts-update .
+docker run -d -rm --name cdli-cts-update \
+  -v /path/to/cdli-data:/data/cdli-data \
+  -v /path/to/cdli-cts:/data/cdli-cts \
+  cdli-cts-update
+```
+
+Then run `docker logs cdli-cts-update` to obtain the container's
+ssh public key. Set this as a deployment key on the
+[cdli-cts](https://github.com/cdli-gh/cdli-cts)
+repository with write permission so the container can push
+changes. You can bind-mount a `.ssh` directory to `/root/.ssh`
+in the container if you want to set the deployment key externally.
+
+Edit the `included_*` lists in `cdli2cts.py` to change what is
+included in the conversion.
+
+The script expects to find working checkouts of the bulk data export
+repo in `/data/cdli-data` and of this repo in `/data/cdli-cts`.
+If you provide a cdli-cts repo, it must be set up to push to
+its origin repo.
+
+If no bind mount is provided, the container will create fresh
+clones at startup. You can save the significant bandwidth of
+the download on subsequent runs by mounting a persistent storage
+volume over `/data`.
+
+Be ware of bind-mounting the same cdli-cts checkout where you're
+editing the scripts. The container will clobber any changes.
+
+## Environment
+
+The following variables can be set to control where `run.sh` looks
+for resources:
+
+- `DATA_PATH` : Location of the cdli-data repository checkout.
+- `CTS_PATH` : Location of the cdli-cts repository checkout.
+- `INTERVAL` : How long to wait (in seconds) between invocations
+  of `cdli2cts`.
+- `SSH_KEY` : Location of the ssh public key file to use for pushes.
+
+For example, you could change the update interval with
+
+    docker run --env INTERVAL=300 cdli-cts-update
+
+Please file an issue if you have any questions or suggestions.

--- a/update/cdli.py
+++ b/update/cdli.py
@@ -1,0 +1,59 @@
+'Common routines for accessing the CDLI catalogue.'
+
+import io
+import os
+import csv
+import fileinput
+
+files = [
+    'cdli_catalogue_1of2.csv',
+    'cdli_catalogue_2of2.csv',
+]
+
+
+def as_utf8(filename, mode='r'):
+    '''Return a file opened as UTF-8 text.
+
+    The gives correct unicode strings on systems where the
+    default text encoding is different.'''
+    return io.open(filename, mode, encoding='utf-8')
+
+
+def _catalogue_reader(data_path):
+    'Helper returning a DictReader instance over the data.'
+
+    filenames = [os.path.join(data_path, fn) for fn in files]
+
+    csvfile = fileinput.input(files=filenames, openhook=as_utf8)
+    return csv.DictReader(csvfile)
+
+
+def read_catalogue(data_path):
+    '''Concatenate and read the catalogue file data.
+
+    Read catalogue data from the given path, which should
+    be a directory containing the export data files.
+
+    The catalogue is split into multiple smaller files to fit
+    better in a git repository. Open these in sequence and
+    yield a series of dictionaries representing each row.
+
+    The keys in the dictionary are taken from the column labels
+    on the first row.'''
+
+    for row in _catalogue_reader(data_path):
+        yield row
+
+
+def id_from_row(row):
+    'Construct a CDLI id from a catalogue data dictionary.'
+
+    # The index is stored as an integer.
+    # CDLI reference numbers start with P and have 6 digits.
+    return f'P{int(row["id_text"]):06d}'
+
+
+def print_entries(data_path):
+    'Dump each row in the catalogue for debugging.'
+    for row in read_catalogue(data_path):
+        print(id_from_row(row), row['designation'])

--- a/update/cdli2cts.py
+++ b/update/cdli2cts.py
@@ -29,7 +29,20 @@ included_ids = [
         'P497322',
 ]
 
-'ATF records to include by catalogue entry.'
+'''ATF records to include by catalogue entry.
+
+This is a dictionary of key, value pairs which, when the given
+key in present in the catalogue metadata for an ATF record and
+the entry exactly matches the given value, the record will be
+converted and included in the output.
+
+Other examples:
+        'genre': 'Literary',
+        'object_type': 'seal',
+        'period': 'Hellenistic (323-63 BC)',
+
+More specific checks can be added to the included() function below.
+'''
 included_metadata = {
         'museum_no': 'BM — PJ',
 }

--- a/update/cdli2cts.py
+++ b/update/cdli2cts.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+'Script to convert the CDLI atf database to a CTS file hierarchy.'
+
+import io
+import os
+import cdli
+import atf2cts
+
+'Catalogue metadata fields to keep for filtering.'
+catalogue_keys = [
+        'designation',
+        'accession_no',
+        'museum_no',
+        'language',
+        'primary_publication',
+        'publication_history',
+        'genre',
+        'object_type',
+        'period',
+        'provenience',
+]
+
+
+'ATF records to include by CDLI id.'
+included_ids = [
+        'P481090',
+        'P464358',
+        'P497322',
+]
+
+'ATF records to include by catalogue entry.'
+included_metadata = {
+        'museum_no': 'BM — PJ',
+}
+
+
+def included(data, id):
+    'Return whether a CDLI id should be included in the conversion.'
+    if id in included_ids:
+        return True
+    for key, value in included_metadata.items():
+        if data[id][key] == value:
+            return True
+    return False
+
+
+def load_catalogue(data_path):
+    'Load catalogue metadata into a dict for reference.'
+    data = {}
+    for row in cdli.read_catalogue(data_path):
+        cdli_id = cdli.id_from_row(row)
+        data[cdli_id] = {key: row[key] for key in catalogue_keys}
+    return data
+
+
+def read_atf(data_path):
+    'Read and segment the atf data export.'
+    filename = os.path.join(data_path, 'cdliatf_unblocked.atf')
+    fp = io.open(filename, encoding='utf-8')
+    for atf in atf2cts.segmentor(fp):
+        # Parse out the CDLI id code.
+        if atf.startswith('&P'):
+            # Drop the '&' sigil and any trailing garbage.
+            cdli_id = atf[1:8]
+        elif atf.startswith('&'):
+            # Handle broken entries with whitespace around the id.
+            token = atf.split()[1]
+            cdli_id = token[0:7]
+            print('Warning: whitespace at the start of &-line.')
+        else:
+            cdli_id = ''
+        # Check if we found what looks like a cdli id.
+        if not cdli_id.startswith('P') or not cdli_id[1:].isdecimal():
+            print("Error: ATF record doesn't start with a CDLI id!")
+            print(atf.splitlines()[0])
+            continue
+        # Parse out the language header, if any.
+        language = None
+        for line in atf.splitlines():
+            if line.startswith('#atf') and 'lang' in line:
+                part = line.split('lang')
+                # Skip spurious equal signs.
+                # These are invalid syntax, but occur sometimes.
+                if part[1].strip() == '=':
+                    del part[1]
+                language = part[1].strip()
+                break
+        yield (cdli_id, language, atf)
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Convert the CDLI bulk export data to CTS.')
+    parser.add_argument(
+        '-d', '--data_path', required=True,
+        help='path to a directory containing the exporet data files.')
+    parser.add_argument(
+        '-o', '--output_path', required=True,
+        help='path to write the CTS file hierarchy under.')
+    args = parser.parse_args()
+
+    print('Loading catalogue from', args.data_path)
+    data = load_catalogue(args.data_path)
+    print('Parsing atf data from', args.data_path)
+    output_path = os.path.join(args.output_path, 'data')
+    successful = 0
+    parse_failures = 0
+    export_failures = 0
+    missing = []
+    extra = []
+    atf_ids = set()
+    for cdli_id, language, atf in read_atf(args.data_path):
+        atf_ids.add(cdli_id)
+        if cdli_id not in data:
+            print('WARNING: atf not in catalogue', cdli_id)
+            missing.append(cdli_id)
+            continue
+        if included(data, cdli_id):
+            s, p, e = atf2cts.convert(atf, output_path)
+            successful += s
+            parse_failures += p
+            export_failures += e
+
+    if parse_failures:
+        print('Error:', parse_failures, 'records did not convert.')
+    if export_failures:
+        print('Error:', export_failures, 'records did not serialize.')
+    print(f'Successfully converted {successful} records from ATF.')
+
+    if missing:
+        print(f'{len(missing)} atf records do not have catalogue entries:')
+        print(','.join(missing))
+    atf_available = [key for key in data.keys() if key in atf_ids]
+    ratio = len(atf_available)/len(data)
+    print(f'{ratio*100:0.2f}% of catalogue entries have atf records.')

--- a/update/run.sh
+++ b/update/run.sh
@@ -1,0 +1,97 @@
+#!/bin/sh -e
+
+# Periodically pull, run the conversion, and push changes from
+# the bulk data export repo to the cdli-cts repo.
+
+# Log the time we started running.
+echo "--- launch $(date -u) ---"
+
+# Configuration.
+# Can be overridden by setting the same variables in the environment.
+: ${DATA_PATH:=/data/cdli-data}
+: ${CTS_PATH:=/data/cdli-cts}
+: ${INTERVAL:=21600}
+
+: ${APPDIR:=$(dirname $0)}
+: ${PYTHONPATH:=$APPDIR/atf2tei}
+: ${SSH_KEY:=$HOME/.ssh/id_rsa.pub}
+
+# Set up the environment if requested.
+if [ "$1" == "--setup" ]; then
+
+  echo "--- setup  $(date -u) ---"
+
+  # Checkout the data repo if none was provided.
+  if ! [ -d ${DATA_PATH}/.git ]; then (
+    set -x
+    mkdir -p $(dirname ${DATA_PATH})
+    git clone --depth 10 https://github.com/cdli-gh/data ${DATA_PATH}
+  )
+  fi
+
+  # Checkout the cdli-cts repo if none was provided.
+  # Set up push over ssh for uploading new conversions.
+  if ! [ -d ${CTS_PATH}/.git ]; then (
+    set -x
+    mkdir -p $(dirname ${CTS_PATH})
+    git clone --depth 10 https://github.com/cdli-gh/cdli-cts ${CTS_PATH}
+    git -C ${CTS_PATH} remote set-url origin --push git@github.com:cdli-gh/cdli-cts
+    git -C ${CTS_PATH} config user.name "CDLI CTS Update"
+    git -C ${CTS_PATH} config user.email "no-reply@cdli.ucla.edu"
+  )
+  fi
+
+  # Generate an ssh keypair if none was provided.
+  if ! [ -f ${SSH_KEY} ]; then (
+    set -x
+    ssh-keygen -N '' -f ${SSH_KEY%.pub}
+  )
+  fi
+  # Write the public half of the keypair to the log
+  # so we can be authorized out-of-band to push changes.
+  cat ${SSH_KEY}
+
+fi # End of set up.
+
+# Loop forever, periodically running a conversion.
+while /bin/true; do
+
+  # Log the time we started running.
+  echo "--- start  $(date -u) ---"
+
+  # Start logging commands.
+  set -x
+
+  # Update the upstream data repo.
+  git -C ${DATA_PATH} pull
+  commit=$(git -C ${DATA_PATH} rev-parse HEAD)
+
+  # Reset to the latest upstream cts revision.
+  git -C ${CTS_PATH} fetch
+  git -C ${CTS_PATH} reset --hard origin/master
+
+  # Run the conversion.
+  rm -rf ${CTS_PATH}/data
+  PYTHONPATH=${PYTHONPATH} pipenv run python cdli2cts.py \
+    -d ${DATA_PATH} \
+    -o ${CTS_PATH}
+
+  # Report and commit any changes.
+  git -C ${CTS_PATH} add data
+  git -C ${CTS_PATH} status
+  git -C ${CTS_PATH} commit -m "Updated from data commit ${commit}" && \
+  git -C ${CTS_PATH} push
+
+  # Stop logging commands.
+  set +x
+
+  # Log the time we finished running.
+  echo "--- finish $(date -u) ---"
+
+  # Wait until it's time to run the job again.
+  sleep ${INTERVAL}
+
+done # End of run loop.
+
+# Log the final time.
+echo "--- exit   $(date -u) ---"


### PR DESCRIPTION
Add an update directory to the CTS repository with the scripts for maintaining it.

- `cdli2cts.py` is a python script wrapping `atf2cts` filtering `cdliatf_unblocked.atf` based on CDLI id code and catalogue metadata.
- `cdli.py` is a python module wrapping the `cdli_catalog_nofm.csv` files.
- `run.sh` periodically pulls from [data](https://github.com/cdli-gh/data), invokes `cdli2cts.py`, and pushes any changes to this repo.
- `Dockerfile` describes a container with all of the above.

There's also a brief setup guide in the README.

This repository will eventually be pretty large, so we may want to move the Docker config and data wrappers to their own repo, but it's nice for discovery to have the update scripts included with the data.

The container entrypoint is a shell script, which I find a better fit for list-of-command scripting like this. If you're concerned about maintainability, I can do it in Python instead. That would also make sense if we added webhook support for triggering updates from data repo changes, so I'd prefer to do it later.